### PR TITLE
Use day-month-year instead of year-month-day

### DIFF
--- a/js/convert.js
+++ b/js/convert.js
@@ -253,7 +253,7 @@ const BankMapper = function (bank) {
             }
         }
 
-        return year + "-" + month + "-" + day;
+        return day + "-" + month + "-" + year;
     };
 
     /**


### PR DESCRIPTION
For me it is a bit weird to use year-month-day for a Dutch project, where day-month-year is the standard. With the current situation, every import i have to pick a different date type in YNAB to have it recognize the transactions correctly.

![2020-07-28 17_43_42](https://user-images.githubusercontent.com/12446338/88688740-f7243200-d0f9-11ea-98de-bb72c5ea29fc.jpg)


My YNAB is configured like this, which conforms to the regional settings of the Netherlands:

![2020-07-28 17_37_11-](https://user-images.githubusercontent.com/12446338/88688284-72391880-d0f9-11ea-989b-a1b9cc656941.jpg)

It even says (on line 227) that the function outputs European format, but doesn't so! 😉 
