### PR TITLE
Add docker file with .env support

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,2 @@
+SYNC=true
+PAT=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+ARG SYNC
+ARG PAT
+WORKDIR /ynabgoingdutch
+RUN apk add git && git clone https://github.com/DanielsWrath/YNABGoingDutch.git . && \
+    sed -i "s/let _autoSync = false;/let _autoSync = $SYNC;/g" js/settingsStorage.js && \
+    sed -i "s/let _pat = \"\";/let _pat = \"$PAT\";/g" js/settingsStorage.js
+COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ If you have any problems or issues while using YNABGoingDutch, please create an 
 
 ## Just let me use it!
 The latest version of the master branch can be used on [GitHub Pages](https://danielswrath.github.io/YNABGoingDutch).
+
+### Docker
+A Dockerfile and docker-compose.yml is added, which can be used to run the project locally and set the PAT as environment variable. Copy .env-example to .env and add your PAT and run:
+
+``docker compose up --build``
+
+Now the application will be available in your browser on http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+    app:
+        container_name: ynabgoingdutch
+        image: ynabgoingdutch
+        build:
+            context: .
+            dockerfile: Dockerfile
+            args:
+                SYNC:
+                PAT:
+        restart: always
+        ports:
+            - "8080:8080"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+events {}
+http {
+    include mime.types;
+    sendfile on;
+
+    server {
+        listen 8080;
+        listen [::]:8080;
+
+        resolver 127.0.0.11;
+        autoindex off;
+
+        server_name _;
+        server_tokens off;
+
+        root /ynabgoingdutch;
+        gzip_static on;
+
+        location / {
+            ssi on;
+        }
+    }
+}


### PR DESCRIPTION
Currently you can clone the project and open the index.html file but this causes the browser to open it as a file instead of serving it locally.

I added a simple docker setup with NGINX to serve the files on http://localhost:8080 and a .env-example file that can be copied to .env to set PAT and SYNC settings. The variables are used only during build time to replace the value in js/settingsStorage.js so it won't be affected when running it without docker. With the .env file you can easily pull the latest master and keep your settings. Check the updated README.md for more information.